### PR TITLE
fix a url

### DIFF
--- a/data/2015/11/index.json
+++ b/data/2015/11/index.json
@@ -944,7 +944,7 @@
         },
         {
             "title": "From Karma to Mocha, with a taste of jsdom — Podio Engineering Blog — Medium",
-            "url": "https://medium.com/podio-engineering-blog/from-karma-to-mocha-with-a-taste-of-jsdom-c9c703a06b21#.ifxxvh9d3",
+            "url": "https://medium.com/podio-engineering-blog/from-karma-to-mocha-with-a-taste-of-jsdom-c9c703a06b21",
             "content": "KarmaからMocha+jsdomへテストを移行した話。\nIsolationの仕組み、全テストの実行時間、単独のテストケース実行、監視などそれぞの項目における比較が書かれている",
             "tags": [
                 "JavaScript",


### PR DESCRIPTION
「[From Karma to Mocha, with a taste of jsdom — Podio Engineering Blog — Medium](https://medium.com/podio-engineering-blog/from-karma-to-mocha-with-a-taste-of-jsdom-c9c703a06b21)」の URL に不要と思われる hash が付いていたので削除しました。
