### PR TITLE
Fix wrong option name in "Node v12.12.0 (Current) | Node.js"

### DIFF
--- a/data/2019/10/index.json
+++ b/data/2019/10/index.json
@@ -307,7 +307,7 @@
             "date": "2019-10-12T14:42:03.172Z",
             "title": "Node v12.12.0 (Current) | Node.js",
             "url": "https://nodejs.org/en/blog/release/v12.12.0/",
-            "content": "Node.js 12.12.0リリース。\n`fs.opendir()`、`fs.Dir`の追加、`--source-map-support`でのスタックトレースのSource Mapサポートなど",
+            "content": "Node.js 12.12.0リリース。\n`fs.opendir()`、`fs.Dir`の追加、`--enable-source-maps`でのスタックトレースのSource Mapサポートなど",
             "tags": [
                 "node.js",
                 "ReleaseNote"


### PR DESCRIPTION
See also https://github.com/nodejs/nodejs.org/pull/2676.