### PR TITLE
SWR v2.0.0-rc.0 の変更内容を修正

### DIFF
--- a/data/2022/10/index.json
+++ b/data/2022/10/index.json
@@ -185,7 +185,7 @@
             "date": "2022-10-06T01:25:20.055Z",
             "title": "Release 2.0.0-rc.0 · vercel/swr",
             "url": "https://github.com/vercel/swr/releases/tag/2.0.0-rc.0",
-            "content": "SWR 2.0.0-rc.0リリース。\n破壊的変更としてmutationにおけるエラーが他のmutationやuseSWRに反映されないように変更。また、mutationがエラーをthrowするかを抑制できる`throwOnError`オプションを追加など,
+            "content": "SWR 2.0.0-rc.0リリース。\n破壊的変更としてmutationにおけるエラーが他のmutationやuseSWRに反映されないように変更。また、mutationがエラーをthrowするかを抑制できる`throwOnError`オプションを追加など",
             "tags": [
                 "React",
                 "JavaScript",

--- a/data/2022/10/index.json
+++ b/data/2022/10/index.json
@@ -185,7 +185,7 @@
             "date": "2022-10-06T01:25:20.055Z",
             "title": "Release 2.0.0-rc.0 · vercel/swr",
             "url": "https://github.com/vercel/swr/releases/tag/2.0.0-rc.0",
-            "content": "SWR 2.0.0-rc.0リリース。\nmutationにおけるエラーをthrowするように変更し、それを抑制できる`throwOnError`オプションを追加など",
+            "content": "SWR 2.0.0-rc.0リリース。\nmutationにおけるエラーが他のmutationやuseSWRに反映されないようにする破壊的変更や、mutation がエラーをthrowするかどうか抑制できる`throwOnError`オプションを追加など",
             "tags": [
                 "React",
                 "JavaScript",

--- a/data/2022/10/index.json
+++ b/data/2022/10/index.json
@@ -185,7 +185,7 @@
             "date": "2022-10-06T01:25:20.055Z",
             "title": "Release 2.0.0-rc.0 · vercel/swr",
             "url": "https://github.com/vercel/swr/releases/tag/2.0.0-rc.0",
-            "content": "SWR 2.0.0-rc.0リリース。\nmutationにおけるエラーが他のmutationやuseSWRに反映されないようにする破壊的変更や、mutation がエラーをthrowするかどうか抑制できる`throwOnError`オプションを追加など",
+            "content": "SWR 2.0.0-rc.0リリース。\n破壊的変更としてmutationにおけるエラーが他のmutationやuseSWRに反映されないように変更。また、mutationがエラーをthrowするかを抑制できる`throwOnError`オプションを追加など,
             "tags": [
                 "React",
                 "JavaScript",


### PR DESCRIPTION
いつもありがとうございます！

細かいですが、
https://github.com/vercel/swr/releases/tag/2.0.0-rc.0
の内容について異なる点があったので修正するための PR です！

下記の 2 点が今回の変更点になります。
- mutation で起きた error はローカルで処理され、他の useSWR や mutate などとは共有されない（破壊的変更）
- 今まで `mutate` でエラーがあった場合はエラーが throw されていたけど、それを throw しないようにする `throwOnError` オプションが追加。（この場合は、`useSWR` や `useSWRMutation` の返り値の `error` で結果を取得できる）