### PR TITLE
Fix protocol-relative URLs to use explicit HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <![endif]-->
     <link type="text/css" href="css/style.css" rel="stylesheet"/>
     <link type="text/css" href="css/jquery.calendarPicker.css" rel="stylesheet"/>
-    <link type="text/css" href="//ajax.googleapis.com/ajax/libs/jqueryui/1/themes/ui-lightness/jquery-ui.css"
+    <link type="text/css" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1/themes/ui-lightness/jquery-ui.css"
           rel="stylesheet">
     <script src="js/vender/jquery.min.js"></script>
     <script src="js/vender/jquery-ui.min.js"></script>
@@ -23,7 +23,7 @@
     <script src="js/script.js"></script>
     <script src="js/app-client.js"></script>
     <script src="js/edit-on-github.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/screenfull.js/1.0.4/screenfull.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/screenfull.js/1.0.4/screenfull.min.js"></script>
 </head>
 <body>
 <div id="controller">


### PR DESCRIPTION
Replace protocol-relative URLs (//) with explicit HTTPS URLs for external resources (jQuery UI CSS and screenfull.js). This prevents potential protocol downgrade attacks when the page is accessed over an insecure HTTP connection, which could allow man-in-the-middle attacks to serve malicious content.