### PR TITLE
Markstreamを追加

### DIFF
--- a/data/2026/07/index.json
+++ b/data/2026/07/index.json
@@ -293,6 +293,25 @@
                 "library"
             ],
             "relatedLinks": []
+        },
+        {
+            "date": "2026-07-19T08:21:24.000Z",
+            "title": "Markstream: Streaming Markdown renderers for AI apps",
+            "url": "https://markstream.simonhe.me/",
+            "content": "AIチャット向けのストリーミングMarkdownレンダラー。\n未完成のMarkdownを逐次レンダリングでき、Vue/React/Svelte/Angular向けパッケージとNuxt/Next.jsの統合ドキュメントを提供する。\nMermaid、KaTeX、Shiki/Monacoによるコード表示、SSRに対応している。",
+            "tags": [
+                "JavaScript",
+                "TypeScript",
+                "Markdown",
+                "library",
+                "AI"
+            ],
+            "relatedLinks": [
+                {
+                    "title": "Simon-He95/markstream-vue: Multi-framework streaming Markdown renderers for AI apps",
+                    "url": "https://github.com/Simon-He95/markstream-vue"
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
## 概要

AIチャット向けのストリーミングMarkdownレンダラー「Markstream」の紹介データを追加しました。

- URL: https://markstream.simonhe.me/
- GitHub: https://github.com/Simon-He95/markstream-vue
- Vue/React/Svelte/Angular向けパッケージを提供
- 未完成のMarkdownの逐次レンダリング、Mermaid、KaTeX、コード表示、SSRに対応

説明文は、誇張を避けてドキュメントに記載されている機能を客観的にまとめています。リポジトリ内のデータ、Issue、Pull Requestを検索し、既存のMarkstream投稿がないことも確認しました。

## 確認

- `pnpm test` 実行済み

開示: 私はMarkstreamのメンテナーです。ご確認いただきありがとうございます。
